### PR TITLE
Upgrading the Dockerfile maven and openjdk image versions to fix the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.6-openjdk-11 as build
+FROM maven:3.8.7-openjdk-18 as build
 WORKDIR /workspace/app
 
 COPY pom.xml .
@@ -9,8 +9,8 @@ COPY . .
 RUN mvn clean package -Dmaven.test.skip=true
 
 
-FROM openjdk:17.0.2-buster
+FROM openjdk:18.0.2-buster
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/target/dependency
-COPY --from=build /workspace/app/target/sample-spring-kotlin-microservice-1.4.0.jar app.jar
+COPY --from=build /workspace/app/target/sample-spring-kotlin-microservice-1.5.0.jar app.jar
 ENTRYPOINT ["java","-jar", "app.jar"]


### PR DESCRIPTION

While trying to build the Dockerfile, the error "java.lang.UnsupportedClassVersionError: org/springframework/boot/maven/BuildInfoMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0" is being thrown. Upgrading the versions removes this error. Additionally, the jar version was upgraded to 1.5 instead of 1.4